### PR TITLE
Change the QSFP identifier byte to 0x0

### DIFF
--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
@@ -28,7 +28,7 @@ class Sff8636MemMap(XcvrMemMap):
         )
 
         self.SERIAL_ID = RegGroupField(consts.SERIAL_ID_FIELD,
-            CodeRegField(consts.ID_FIELD, self.get_addr(0, 128), self.codes.XCVR_IDENTIFIERS),
+            CodeRegField(consts.ID_FIELD, self.get_addr(0, 0), self.codes.XCVR_IDENTIFIERS),
             CodeRegField(consts.ID_ABBRV_FIELD, self.get_addr(0, 0), self.codes.XCVR_IDENTIFIER_ABBRV),
             RegGroupField(consts.EXT_ID_FIELD, 
                 CodeRegField(consts.POWER_CLASS_FIELD, self.get_addr(0, 129), self.codes.POWER_CLASSES,

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
@@ -29,7 +29,7 @@ class Sff8636MemMap(XcvrMemMap):
 
         self.SERIAL_ID = RegGroupField(consts.SERIAL_ID_FIELD,
             CodeRegField(consts.ID_FIELD, self.get_addr(0, 128), self.codes.XCVR_IDENTIFIERS),
-            CodeRegField(consts.ID_ABBRV_FIELD, self.get_addr(0, 128), self.codes.XCVR_IDENTIFIER_ABBRV),
+            CodeRegField(consts.ID_ABBRV_FIELD, self.get_addr(0, 0), self.codes.XCVR_IDENTIFIER_ABBRV),
             RegGroupField(consts.EXT_ID_FIELD, 
                 CodeRegField(consts.POWER_CLASS_FIELD, self.get_addr(0, 129), self.codes.POWER_CLASSES,
                     RegBitField("%s_0" % consts.POWER_CLASS_FIELD, 0),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Change the identifier byte for SFF8636 to byte 0

#### Motivation and Context
Some modules may behave weirdly where if we read the byte 128 which should read the same as byte 0, but does not in following sequence.

1. read offset 127
2. immediately read offset 128

```
root@lc03:~# i2cget -f -y 45 0x50 0x7f && i2cget -f -y 45 0x50 128
0x00
0x00   << Incorrect
root@lc03:~# i2cget -f -y 45 0x50 0x7f
0x00
root@lc03:~# i2cget -f -y 45 0x50 128
0x00

After 5 sec delay

root@lc03:~# i2cget -f -y 45 0x50 128
0x11 << correct
root@lc03:~# i2cget -f -y 45 0x50 128
0x11 << correct
root@lc03:~# i2cget -f -y 45 0x50 128
0x11
root@lc03:~# i2cget -f -y 45 0x50 0x7f && i2cget -f -y 45 0x50 128
0x00
0x00
root@lc03:~#
```

#### How Has This Been Tested?
Tested this change on the buggy module and it reported the identifier correctly.

This is a low risk change because the Xcvr API factor reads byte 0x0 to instantiate the API class appropriately for each transciver type and if that itself is read incorrectly, then the Xcvrd cannot operate on that module.

#### Additional Information (Optional)

